### PR TITLE
Add bundler as a runtime dependency

### DIFF
--- a/libevdev.gemspec
+++ b/libevdev.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "linux_input", "~> 1.0"
-  spec.add_development_dependency "bundler", "~> 1.8"
+  spec.add_runtime_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
The very first line of libevdev.rb requires bundler.
Without having bundler installed trying to load this gem will fail with an exception.